### PR TITLE
Fixes illegal characters error

### DIFF
--- a/src/OAuth/Common/Storage/Session.php
+++ b/src/OAuth/Common/Storage/Session.php
@@ -33,8 +33,8 @@ class Session implements TokenStorageInterface
      */
     public function __construct(
         $startSession = true,
-        $sessionVariableName = 'lusitanian_oauth_token',
-        $stateVariableName = 'lusitanian_oauth_state'
+        $sessionVariableName = 'lusitanian-oauth-token',
+        $stateVariableName = 'lusitanian-oauth-state'
     ) {
         if ($startSession && !isset($_SESSION)) {
             session_start();


### PR DESCRIPTION
Fixes the following:

```
session_start(): The session id is too long or contains illegal characters, valid characters are a-z, A-Z, 0-9 and '-,'
```